### PR TITLE
Replaced mocha/mini_test with mocka/minitest in tests helper.

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,5 +1,5 @@
 require 'minitest/autorun'
 require 'minitest/unit'
 require 'shoulda'
-require 'mocha/mini_test'
+require 'mocha/minitest'
 require 'jekyll-autolink_email'


### PR DESCRIPTION
"mocha/mini_test" is deprecated. 