### PR TITLE
Fix can't modify frozen String error

### DIFF
--- a/jekyll-autolink_email.gemspec
+++ b/jekyll-autolink_email.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "jekyll", '~> 3.0'
+  spec.add_dependency "jekyll", ['>= 3.0', '< 5.0']
   spec.add_dependency "rinku", '~> 1.7.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"

--- a/jekyll-autolink_email.gemspec
+++ b/jekyll-autolink_email.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", ['>= 3.0', '< 5.0']
   spec.add_dependency "rinku", '~> 1.7.0'
+  spec.add_dependency "jekyll-email-protect", '~> 1.0'
 
   spec.add_development_dependency "bundler", "~> 1.6"
   spec.add_development_dependency "rake"

--- a/lib/jekyll-autolink_email.rb
+++ b/lib/jekyll-autolink_email.rb
@@ -1,8 +1,11 @@
 require 'jekyll'
 require 'rinku'
+require 'jekyll-email-protect'
 
 module Jekyll
   class AutolinkEmail < Jekyll::Generator
+
+    include Jekyll::EmailProtect::EmailProtectionFilter
 
     HTML_ENTITIES = {
       '@' => '&#064;',
@@ -48,7 +51,7 @@ module Jekyll
     # A hack since Rinku doesn't offer a hook into changing what the link is
     def url_encode_email_addresses(content)
       content.gsub!(/mailto:(#{email_addresses.join('|')})/) do |m|
-        m[$1] = ERB::Util.url_encode($1)
+        m[$1] = encode_email($1)
         m
       end
     end

--- a/lib/jekyll-autolink_email.rb
+++ b/lib/jekyll-autolink_email.rb
@@ -27,7 +27,7 @@ module Jekyll
     private
 
     def autolinkify(page)
-      page.content = Rinku.auto_link(page.content, :email_addresses, link_attr, skip_tags) do |email_address|
+      page.content = +Rinku.auto_link(page.content, :email_addresses, link_attr, skip_tags) do |email_address|
         if escape?
           email_addresses << email_address.dup
           html_encode(email_address)


### PR DESCRIPTION
Fix `gsub!': can't modify frozen String: "" (FrozenError)` on `ruby 2.7.5`, `rinku 1.7.3`.